### PR TITLE
Add Versioning menu with a Show Versions item

### DIFF
--- a/src/app/window/toolbar.ts
+++ b/src/app/window/toolbar.ts
@@ -58,6 +58,17 @@ const toolbarTemplate = [
         ]
     }),
     new MenuItem({
+        label: 'Versioning',
+        submenu: [
+            {
+                label: 'Show Versions',
+                click: (menuItem, browserWindow) => {
+                    (browserWindow as BrowserWindow).webContents.send('menu-show-versions')
+                }
+            }
+        ]
+    }),
+    new MenuItem({
         label: 'View',
         submenu: [
             {

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -630,6 +630,12 @@ export default class GhostEditor extends View implements ReferenceProvider, Code
             window.ipcRenderer.on('menu-save' ,            ()                        => this.save())
             window.ipcRenderer.on('menu-update-file-path', (filePath: string)        => this.getSession().updateFilePath(filePath))
         }
+
+        if (this.sideViewEnabled) {
+            // Triggers the same Monaco action the "Alt+X" keybinding runs (see setupKeybindings),
+            // rather than duplicating its snapshot-selection logic here.
+            window.ipcRenderer.on('menu-show-versions', () => this.core.getAction("ghost-show-versions")?.run())
+        }
     }
 
     private async setupSideView(): Promise<void> {


### PR DESCRIPTION
Positioned between Edit and View. Triggers the same Monaco action the existing Alt+X keybinding runs, rather than duplicating its snapshot-selection logic.