### PR TITLE
Make Prisma client generation an explicit, visible CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate Prisma Client
+        # @prisma/client's own postinstall already runs `prisma generate`, but it swallows any
+        # failure and always exits 0 (see node_modules/@prisma/client/scripts/postinstall.js), so a
+        # broken generate there fails silently and only surfaces later as a confusing "unable to
+        # locate .prisma/client/schema.prisma glob" error out of webpack's CopyPlugin. Running it
+        # again here, unguarded, turns that into a real, visible failure with Prisma's actual error.
+        run: npx prisma generate
+
       - name: Build package
         run: npm run make
 


### PR DESCRIPTION
@prisma/client's postinstall already runs `prisma generate`, but it always exits 0 even when generation fails, so a broken generate (as apparently happened on windows-latest) fails silently during npm ci and only resurfaces steps later as a confusing "unable to locate .prisma/client/schema.prisma glob" error out of webpack's CopyPlugin. Running it again explicitly surfaces the real error instead.