### PR TITLE
Publish tagged builds to GitHub Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build
 on:
   push:
     branches: [master]
+    tags: ['v*.*.*']
   workflow_dispatch:
 
 jobs:
@@ -48,3 +49,24 @@ jobs:
           name: ghost-editor-${{ matrix.os }}
           path: out/make/**
           if-no-files-found: error
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: ghost-editor-*
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**/*
+          generate_release_notes: true


### PR DESCRIPTION
actions/upload-artifact only attaches files to the triggering workflow run's own Artifacts tab, not the repo's Releases page - the two are unrelated GitHub features. Pushing a vX.Y.Z tag now additionally gathers every platform's maker output (already uploaded per-OS by the existing build job) into one release job and publishes them as release assets via softprops/action-gh-release, so all three installers land on a single release together instead of racing across parallel jobs.